### PR TITLE
allow more http connections to consul api

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 consul_template_config_dir: /etc/consul-template
 consul_template_consul_address: "localhost:8500"
+consul_http_max_conns_per_client: 1000

--- a/templates/consul.hcl.j2
+++ b/templates/consul.hcl.j2
@@ -1,6 +1,10 @@
 consul {
   address = "{{ consul_template_consul_address }}"
 
+  limits {
+    http_max_conns_per_client = 1000
+  }
+
   retry {
     enabled  = true
     attempts = 12

--- a/templates/consul.hcl.j2
+++ b/templates/consul.hcl.j2
@@ -2,7 +2,7 @@ consul {
   address = "{{ consul_template_consul_address }}"
 
   limits {
-    http_max_conns_per_client = 1000
+    http_max_conns_per_client = {{ consul_http_max_conns_per_client }}
   }
 
   retry {


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DATA-898
dw2 consul reports `429 Your IP is issuing too many concurrent connections, please rate limit your calls` w/o this patch